### PR TITLE
refactor BetterPlayer FairPlay DRM implementation for iOS

### DIFF
--- a/ios/Classes/BetterPlayer.m
+++ b/ios/Classes/BetterPlayer.m
@@ -34,6 +34,24 @@ static NSString* BetterPlayerNormalizeNonEmptyString(NSString* value) {
     return normalizedValue.length > 0 ? normalizedValue : nil;
 }
 
+static BOOL BetterPlayerIsRemoteCertificateUrl(NSString* certificateUrl) {
+    NSString* lowerCertificateUrl = [certificateUrl lowercaseString];
+    return [lowerCertificateUrl hasPrefix:@"http://"] || [lowerCertificateUrl hasPrefix:@"https://"];
+}
+
+static NSString* BetterPlayerCertificateUrlPreview(NSString* certificateUrl) {
+    if (certificateUrl.length == 0) {
+        return @"(empty)";
+    }
+    if (BetterPlayerIsRemoteCertificateUrl(certificateUrl)) {
+        return certificateUrl;
+    }
+    const NSUInteger previewLength = MIN((NSUInteger)32, certificateUrl.length);
+    return [NSString stringWithFormat:@"%@... (%lu chars, inline base64)",
+            [certificateUrl substringToIndex:previewLength],
+            (unsigned long)certificateUrl.length];
+}
+
 
 #if TARGET_OS_IOS
 void (^__strong _Nonnull _restoreUserInterfaceForPIPStopCompletionHandler)(BOOL);
@@ -304,14 +322,26 @@ static inline CGFloat radiansToDegrees(CGFloat radians) {
         NSString* normalizedDrmToken = BetterPlayerNormalizeDrmToken(drmToken);
         NSString* normalizedCertificateUrl = BetterPlayerNormalizeNonEmptyString(certificateUrl);
         NSString* normalizedLicenseUrl = BetterPlayerNormalizeNonEmptyString(licenseUrl);
-        // If token is valid, use VuDRM, otherwise keep EzDRM fallback path.
-        if (normalizedDrmToken != nil && normalizedCertificateUrl != nil && normalizedLicenseUrl != nil) {
+        // VuDRM handles token-based providers (e.g. Lionsgate) and inline-certificate providers (e.g. SonyLiv ExpressPlay).
+        if (normalizedCertificateUrl != nil && normalizedLicenseUrl != nil &&
+            (normalizedDrmToken != nil || !BetterPlayerIsRemoteCertificateUrl(normalizedCertificateUrl))) {
+            BOOL isInlineCertificate = !BetterPlayerIsRemoteCertificateUrl(normalizedCertificateUrl);
+            NSLog(@"[BetterPlayer-FairPlay] Using VuDRM delegate (inlineCertificate=%@, hasToken=%@)",
+                  isInlineCertificate ? @"YES" : @"NO",
+                  normalizedDrmToken != nil ? @"YES" : @"NO");
+            NSLog(@"[BetterPlayer-FairPlay] certificateUrl=%@",
+                  BetterPlayerCertificateUrlPreview(normalizedCertificateUrl));
+            NSLog(@"[BetterPlayer-FairPlay] licenseUrl=%@", normalizedLicenseUrl);
             NSURL * licenseNSURL = [[NSURL alloc] initWithString: normalizedLicenseUrl];
             _vuDrmAssetsloaderDelegate = [[BetterPlayerVuDrmAssetsLoaderDelegate alloc]initWithCertificateURL:normalizedCertificateUrl licenseURL:licenseNSURL fairPlayToken:normalizedDrmToken];
             dispatch_queue_attr_t qos = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_DEFAULT, -1);
             dispatch_queue_t streamQueue = dispatch_queue_create("streamQueue", qos);
             [asset.resourceLoader setDelegate:_vuDrmAssetsloaderDelegate queue:streamQueue];
         } else if (normalizedCertificateUrl != nil && normalizedLicenseUrl != nil) {
+            NSLog(@"[BetterPlayer-FairPlay] Using EzDRM delegate");
+            NSLog(@"[BetterPlayer-FairPlay] certificateUrl=%@",
+                  BetterPlayerCertificateUrlPreview(normalizedCertificateUrl));
+            NSLog(@"[BetterPlayer-FairPlay] licenseUrl=%@", normalizedLicenseUrl);
             NSURL * certificateNSURL = [[NSURL alloc] initWithString: normalizedCertificateUrl];
             NSURL * licenseNSURL = [[NSURL alloc] initWithString: normalizedLicenseUrl];
             _loaderDelegate = [[BetterPlayerEzDrmAssetsLoaderDelegate alloc] init:certificateNSURL withLicenseURL:licenseNSURL];

--- a/ios/Classes/BetterPlayerVuDrmAssetsLoaderDelegate.swift
+++ b/ios/Classes/BetterPlayerVuDrmAssetsLoaderDelegate.swift
@@ -13,6 +13,23 @@ import Alamofire
         self.licenseURL = licenseURL
         self.fairPlayToken = fairPlayToken
         super.init()
+        let certPreview = Self.previewCertificateValue(certificateURL ?? "")
+        let licensePreview = licenseURL?.absoluteString ?? "(nil)"
+        let hasToken = !(fairPlayToken ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        NSLog("[BetterPlayer-FairPlay] VuDRM delegate init certificateUrl=%@ licenseUrl=%@ hasToken=%@",
+              certPreview, licensePreview, hasToken ? "YES" : "NO")
+    }
+
+    private static func previewCertificateValue(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty { return "(empty)" }
+        let lower = trimmed.lowercased()
+        if lower.hasPrefix("http://") || lower.hasPrefix("https://") {
+            return trimmed
+        }
+        let previewLength = min(32, trimmed.count)
+        let prefix = String(trimmed.prefix(previewLength))
+        return "\(prefix)... (\(trimmed.count) chars, inline base64)"
     }
 
     private var normalizedFairPlayToken: String? {
@@ -23,86 +40,172 @@ import Alamofire
         }
         return token
     }
-    
-    public func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
-        
-        let url = self.certificateURL ?? ""
+
+    private func isRemoteCertificateUrl(_ value: String) -> Bool {
+        let lower = value.lowercased()
+        return lower.hasPrefix("http://") || lower.hasPrefix("https://")
+    }
+
+    private func sanitizeInlineCertificate(_ value: String) -> String {
+        var cleaned = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if cleaned.contains("-----BEGIN CERTIFICATE-----") {
+            cleaned = cleaned
+                .replacingOccurrences(of: "-----BEGIN CERTIFICATE-----", with: "")
+                .replacingOccurrences(of: "-----END CERTIFICATE-----", with: "")
+                .replacingOccurrences(of: "\\s+", with: "", options: .regularExpression)
+        } else {
+            cleaned = cleaned.replacingOccurrences(of: "\\s+", with: "", options: .regularExpression)
+        }
+        return cleaned
+    }
+
+    private func decodeInlineCertificate(_ value: String) -> Data? {
+        let sanitized = sanitizeInlineCertificate(value)
+        NSLog("[BetterPlayer-FairPlay] Decoding inline certificateUrl: rawLength=%d sanitizedLength=%d preview=%@",
+              value.count, sanitized.count, Self.previewCertificateValue(value))
+
+        if sanitized.isEmpty {
+            NSLog("[BetterPlayer-FairPlay] Inline certificate decode failed: sanitized value is empty")
+            return nil
+        }
+
+        if let decoded = Data(base64Encoded: sanitized, options: [.ignoreUnknownCharacters]), !decoded.isEmpty {
+            NSLog("[BetterPlayer-FairPlay] Inline certificate decoded via standard base64 (%d bytes)", decoded.count)
+            return decoded
+        }
+
+        let urlSafe = sanitized
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+        let padding = urlSafe.count % 4
+        let padded = padding == 0 ? urlSafe : urlSafe + String(repeating: "=", count: 4 - padding)
+        if let decoded = Data(base64Encoded: padded, options: [.ignoreUnknownCharacters]), !decoded.isEmpty {
+            NSLog("[BetterPlayer-FairPlay] Inline certificate decoded via URL-safe base64 (%d bytes)", decoded.count)
+            return decoded
+        }
+
+        if let decoded = extractCertificateData(from: sanitized.data(using: .utf8)), !decoded.isEmpty {
+            NSLog("[BetterPlayer-FairPlay] Inline certificate decoded via extractCertificateData (%d bytes)", decoded.count)
+            return decoded
+        }
+
+        NSLog("[BetterPlayer-FairPlay] Inline certificate decode failed for sanitizedLength=%d", sanitized.count)
+        return nil
+    }
+
+    private func loadCertificate(completion: @escaping (Data?) -> Void) {
+        let rawCertificateValue = (certificateURL ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawCertificateValue.isEmpty else {
+            NSLog("[BetterPlayer-FairPlay] Certificate load failed: certificateUrl is empty")
+            completion(nil)
+            return
+        }
+
+        if !isRemoteCertificateUrl(rawCertificateValue) {
+            NSLog("[BetterPlayer-FairPlay] certificateUrl type=inline-base64 (SonyLiv/ExpressPlay path)")
+            completion(decodeInlineCertificate(rawCertificateValue))
+            return
+        }
+
+        let certificateValue = sanitizeInlineCertificate(rawCertificateValue)
+        NSLog("[BetterPlayer-FairPlay] certificateUrl type=remote-url value=%@", certificateValue)
         var headers: HTTPHeaders = [:]
-        if let token = self.normalizedFairPlayToken {
+        if let token = normalizedFairPlayToken {
             headers["x-vudrm-token"] = token
             headers["nv-authorizations"] = token
         }
-        request(url, method: .get, headers: headers).validate().responseData { [weak self] response in
+        request(certificateValue, method: .get, headers: headers).validate().responseData { response in
+            if let error = response.error {
+                NSLog("[BetterPlayer-FairPlay] Certificate fetch failed: %@", error.localizedDescription)
+                completion(nil)
+                return
+            }
+            let certificateData = extractCertificateData(from: response.value)
+            if let certificateData = certificateData {
+                NSLog("[BetterPlayer-FairPlay] Remote certificate fetched successfully (%d bytes)", certificateData.count)
+            } else {
+                NSLog("[BetterPlayer-FairPlay] Remote certificate response could not be parsed")
+            }
+            completion(certificateData)
+        }
+    }
+
+    private func processKeyRequest(_ loadingRequest: AVAssetResourceLoadingRequest, certificateData: Data) {
+        guard let licenseUrl = loadingRequest.request.url else {
+            loadingRequest.finishLoading()
+            NSLog("[BetterPlayer-FairPlay] Failed to extract skd license url from loading request")
+            return
+        }
+        NSLog("[BetterPlayer-FairPlay] skd resource url: %@", licenseUrl.absoluteString)
+
+        let contentId = extractContentId(from: licenseUrl) ?? licenseUrl.absoluteString
+        guard
+            let contentIdData = contentId.data(using: .utf8),
+            let spcData = try? loadingRequest.streamingContentKeyRequestData(forApp: certificateData, contentIdentifier: contentIdData, options: nil),
+            let dataRequest = loadingRequest.dataRequest else {
+            loadingRequest.finishLoading()
+            NSLog("[BetterPlayer-FairPlay] Failed to create SPC (contentId=%@)", contentId)
+            return
+        }
+        NSLog("[BetterPlayer-FairPlay] SPC created (contentId=%@, spcBytes=%d)", contentId, spcData.count)
+
+        let fallbackLicenseURL = licenseUrl.absoluteString.replacingOccurrences(of: "skd", with: "https")
+        let targetLicenseURLString = licenseURL?.absoluteString ?? fallbackLicenseURL
+        guard let targetLicenseURL = URL(string: targetLicenseURLString) else {
+            NSLog("[BetterPlayer-FairPlay] Failed to parse license server url: %@", targetLicenseURLString)
+            loadingRequest.finishLoading()
+            return
+        }
+        NSLog("[BetterPlayer-FairPlay] Posting SPC to license server: %@", targetLicenseURL.absoluteString)
+
+        var urlRequest = URLRequest(url: targetLicenseURL)
+        urlRequest.httpMethod = "POST"
+        urlRequest.httpBody = spcData
+        urlRequest.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        if let token = normalizedFairPlayToken {
+            urlRequest.setValue(token, forHTTPHeaderField: "nv-authorizations")
+            urlRequest.setValue(token, forHTTPHeaderField: "x-vudrm-token")
+            urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            NSLog("[BetterPlayer-FairPlay] License request includes drm token")
+        }
+
+        request(urlRequest).validate().responseData { response in
+            if let error = response.error {
+                NSLog("[BetterPlayer-FairPlay] CKC fetch failed: %@", error.localizedDescription)
+                loadingRequest.finishLoading()
+                return
+            }
+
+            if let data = response.value {
+                if let ckcData = extractCkcData(from: data) {
+                    NSLog("[BetterPlayer-FairPlay] CKC fetched successfully (%d bytes)", ckcData.count)
+                    dataRequest.respond(with: ckcData)
+                } else {
+                    NSLog("[BetterPlayer-FairPlay] Failed to parse CKC response (%d bytes)", data.count)
+                }
+            } else {
+                NSLog("[BetterPlayer-FairPlay] CKC response was empty")
+            }
+            loadingRequest.finishLoading()
+        }
+    }
+    
+    public func resourceLoader(_ resourceLoader: AVAssetResourceLoader, shouldWaitForLoadingOfRequestedResource loadingRequest: AVAssetResourceLoadingRequest) -> Bool {
+        NSLog("[BetterPlayer-FairPlay] FairPlay key request started")
+        loadCertificate { [weak self] certificateData in
             guard let self = self else {
                 loadingRequest.finishLoading()
                 return
             }
-            if let error = response.error {
-                print("❌ Error on fetching certificate! -> \(error.localizedDescription)")
+            guard let certificateData = certificateData else {
+                NSLog("[BetterPlayer-FairPlay] FairPlay key request aborted: certificate decode returned nil")
                 loadingRequest.finishLoading()
                 return
             }
-            let certificateData = extractCertificateData(from: response.value)
-            
-            guard let licenseUrl = loadingRequest.request.url else {
-                loadingRequest.finishLoading()
-                print("❌ Error on extracting license url!")
-                return
-            }
-            print("✅ License url validation passed: -> \(licenseUrl)")
-            
-            // create SPC Message
-            let contentId = extractContentId(from: licenseUrl) ?? licenseUrl.absoluteString
-            guard
-                let certificateData = certificateData,
-                let contentIdData = contentId.data(using: .utf8),
-                let spcData = try? loadingRequest.streamingContentKeyRequestData(forApp: certificateData, contentIdentifier: contentIdData, options: nil),
-                let dataRequest = loadingRequest.dataRequest else {
-                    loadingRequest.finishLoading()
-                print("❌ Error on creating SPC Message! contentId: \(contentId)")
-                    return
-            }
-            
-            // get CKC
-            let fallbackLicenseURL = licenseUrl.absoluteString.replacingOccurrences(of: "skd", with: "https")
-            let targetLicenseURLString = self.licenseURL?.absoluteString ?? fallbackLicenseURL
-            guard let targetLicenseURL = URL(string: targetLicenseURLString) else {
-                print("❌ Error on parsing license url!")
-                loadingRequest.finishLoading()
-                return
-            }
-
-            var urlRequest = URLRequest(url: targetLicenseURL)
-            urlRequest.httpMethod = "POST"
-            urlRequest.httpBody = spcData
-            urlRequest.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
-            if let token = self.normalizedFairPlayToken {
-                urlRequest.setValue(token, forHTTPHeaderField: "nv-authorizations")
-                urlRequest.setValue(token, forHTTPHeaderField: "x-vudrm-token")
-                urlRequest.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            }
-
-            request(urlRequest).validate().responseData { response in
-                if let error = response.error {
-                    print("❌ Error on fetching CKC! -> \(error.localizedDescription)")
-                    loadingRequest.finishLoading()
-                    return
-                }
-                
-                if let data = response.value {
-                    if let ckcData = extractCkcData(from: data) {
-                        print("✅ CKC fetched successfully!")
-                        dataRequest.respond(with: ckcData)
-                    } else {
-                        print("❌ Error on parsing CKC response!")
-                    }
-                } else {
-                    print("❌ Error in CKC data!")
-                }
-                loadingRequest.finishLoading()
-            }
+            NSLog("[BetterPlayer-FairPlay] Certificate ready for SPC (%d bytes)", certificateData.count)
+            self.processKeyRequest(loadingRequest, certificateData: certificateData)
         }
-        
+
         return true
     }
 }
@@ -131,6 +234,7 @@ func extractCkcData(from responseData: Data) -> Data? {
 
 func extractCertificateData(from responseData: Data?) -> Data? {
     guard let responseData = responseData else {
+        NSLog("[BetterPlayer-FairPlay] extractCertificateData: input is nil")
         return nil
     }
 
@@ -141,6 +245,7 @@ func extractCertificateData(from responseData: Data?) -> Data? {
         for key in supportedKeys {
             if let certValue = json[key] as? String,
                let certData = Data(base64Encoded: certValue, options: [.ignoreUnknownCharacters]) {
+                NSLog("[BetterPlayer-FairPlay] extractCertificateData: decoded JSON key '%@' (%d bytes)", key, certData.count)
                 return certData
             }
         }
@@ -151,10 +256,14 @@ func extractCertificateData(from responseData: Data?) -> Data? {
             .trimmingCharacters(in: .whitespacesAndNewlines),
         let base64Data = Data(base64Encoded: responseString, options: [.ignoreUnknownCharacters]),
         !base64Data.isEmpty {
+        NSLog("[BetterPlayer-FairPlay] extractCertificateData: decoded base64 string (%d bytes)", base64Data.count)
         return base64Data
     }
 
-    return responseData
+    if !responseData.isEmpty {
+        NSLog("[BetterPlayer-FairPlay] extractCertificateData: using raw response data (%d bytes)", responseData.count)
+    }
+    return responseData.isEmpty ? nil : responseData
 }
 
 func extractContentId(from skdURL: URL) -> String? {


### PR DESCRIPTION
- Improve  to handle both remote and inline base64 certificates
- Add robust certificate decoding including URL-safe base64 and SAN stripping
- Implement detailed logging for the FairPlay key request lifecycle
- Update  to route SonyLiv/ExpressPlay (inline certificates) through the VuDRM delegate
- Refactor certificate loading and SPC/CKC processing into modular methods